### PR TITLE
Expirable

### DIFF
--- a/contracts/ERC1238/extensions/ERC1238Expirable.sol
+++ b/contracts/ERC1238/extensions/ERC1238Expirable.sol
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import "../ERC1238.sol";
+import "./IERC1238Expirable.sol";
+
+/**
+ * @dev See {IERC1238Expirable}.
+ */
+abstract contract ERC1238Expirable is IERC1238Expirable, ERC1238 {
+    // Optional mapping for token expiry date
+    mapping(uint256 => uint256) private _expiryDate;
+
+    /**
+     * @dev See {IERC1238Expirable-expiryDate}.
+     */
+    function expiryDate(uint256 id) public view virtual override returns (uint256) {
+        uint256 date = _expiryDate[id];
+
+        require(date != 0, "ERC1238Expirable: No expiry date set");
+
+        return date;
+    }
+
+    /**
+     * @dev See {IERC1238Expirable-isExpired}.
+     */
+    function isExpired(uint256 id) public view virtual override returns (bool) {
+        uint256 date = _expiryDate[id];
+
+        require(date != 0, "ERC1238Expirable: No expiry date set");
+
+        return date < block.timestamp;
+    }
+
+    /**
+     * @dev Sets the expiry date for the tokens of type `id`.
+     */
+    function _setExpiryDate(uint256 id, uint256 date) internal virtual {
+        require(date > block.timestamp, "ERC1238Expirable: Expiry date cannot be in the past");
+
+        _expiryDate[id] = date;
+    }
+
+    /**
+     * @dev [Batched] version of {_setExpiryDate}.
+     *
+     */
+    function _setBatchExpiryDates(uint256[] memory ids, uint256[] memory dates) internal {
+        require(ids.length == dates.length, "ERC1238Expirable: Ids and token URIs length mismatch");
+
+        for (uint256 i = 0; i < ids.length; i++) {
+            _setExpiryDate(ids[i], dates[i]);
+        }
+    }
+}

--- a/contracts/ERC1238/extensions/ERC1238Expirable.sol
+++ b/contracts/ERC1238/extensions/ERC1238Expirable.sol
@@ -35,9 +35,12 @@ abstract contract ERC1238Expirable is IERC1238Expirable, ERC1238 {
 
     /**
      * @dev Sets the expiry date for the tokens with id `id`.
+     * Requirements:
+     * - The new date must be after the current expiry date.
      */
     function _setExpiryDate(uint256 id, uint256 date) internal virtual {
         require(date > block.timestamp, "ERC1238Expirable: Expiry date cannot be in the past");
+        require(date > _expiryDate[id], "ERC1238Expirable: Expiry date can only be extended");
 
         _expiryDate[id] = date;
     }

--- a/contracts/ERC1238/extensions/ERC1238Expirable.sol
+++ b/contracts/ERC1238/extensions/ERC1238Expirable.sol
@@ -34,7 +34,7 @@ abstract contract ERC1238Expirable is IERC1238Expirable, ERC1238 {
     }
 
     /**
-     * @dev Sets the expiry date for the tokens of type `id`.
+     * @dev Sets the expiry date for the tokens with id `id`.
      */
     function _setExpiryDate(uint256 id, uint256 date) internal virtual {
         require(date > block.timestamp, "ERC1238Expirable: Expiry date cannot be in the past");
@@ -44,7 +44,6 @@ abstract contract ERC1238Expirable is IERC1238Expirable, ERC1238 {
 
     /**
      * @dev [Batched] version of {_setExpiryDate}.
-     *
      */
     function _setBatchExpiryDates(uint256[] memory ids, uint256[] memory dates) internal {
         require(ids.length == dates.length, "ERC1238Expirable: Ids and token URIs length mismatch");

--- a/contracts/ERC1238/extensions/ERC1238Expirable.sol
+++ b/contracts/ERC1238/extensions/ERC1238Expirable.sol
@@ -52,4 +52,18 @@ abstract contract ERC1238Expirable is IERC1238Expirable, ERC1238 {
             _setExpiryDate(ids[i], dates[i]);
         }
     }
+
+    /**
+     * @dev Publicly expose {_setExpiryDate}.
+     */
+    function setExpiryDate(uint256 id, uint256 date) public {
+        _setExpiryDate(id, date);
+    }
+
+    /**
+     * @dev Publicly expose {_setBatchExpiryDates}.
+     */
+    function setBatchExpiryDates(uint256[] memory ids, uint256[] memory dates) public {
+        _setBatchExpiryDates(ids, dates);
+    }
 }

--- a/contracts/ERC1238/extensions/IERC1238Expirable.sol
+++ b/contracts/ERC1238/extensions/IERC1238Expirable.sol
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import "../IERC1238.sol";
+
+/**
+ * @dev Interface for ERC1238 tokens with an expiry date.
+ * The dates are stored as unix timestamps in seconds.
+ */
+interface IERC1238Expirable is IERC1238 {
+    /**
+     * @dev Returns the expiry date for tokens with a given `id`.
+     */
+    function expiryDate(uint256 id) external view returns (uint256);
+
+    /**
+     * @dev Returns whether tokens are expired by comparing their expiry date with `block.timestamp`.
+     */
+    function isExpired(uint256 id) external view returns (bool);
+}

--- a/contracts/ERC1238/extensions/IERC1238Expirable.sol
+++ b/contracts/ERC1238/extensions/IERC1238Expirable.sol
@@ -17,4 +17,14 @@ interface IERC1238Expirable is IERC1238 {
      * @dev Returns whether tokens are expired by comparing their expiry date with `block.timestamp`.
      */
     function isExpired(uint256 id) external view returns (bool);
+
+    /**
+     * @dev Sets the expiry date for the tokens with id `id`.
+     */
+    function setExpiryDate(uint256 id, uint256 date) external;
+
+    /**
+     * @dev [Batched] version of {setExpiryDate}.
+     */
+    function setBatchExpiryDates(uint256[] memory ids, uint256[] memory dates) external;
 }

--- a/contracts/mocks/ERC1238ExpirableMock.sol
+++ b/contracts/mocks/ERC1238ExpirableMock.sol
@@ -15,6 +15,10 @@ contract ERC1238ExpirableMock is ERC1238, ERC1238Expirable {
         _setExpiryDate(id, date);
     }
 
+    function setBatchExpiryDates(uint256[] memory ids, uint256[] memory dates) external {
+        _setBatchExpiryDates(ids, dates);
+    }
+
     function mintToEOA(
         address to,
         uint256 id,

--- a/contracts/mocks/ERC1238ExpirableMock.sol
+++ b/contracts/mocks/ERC1238ExpirableMock.sol
@@ -11,14 +11,6 @@ contract ERC1238ExpirableMock is ERC1238, ERC1238Expirable {
 
     constructor(string memory uri) ERC1238(uri) {}
 
-    function setExpiryDate(uint256 id, uint256 date) external {
-        _setExpiryDate(id, date);
-    }
-
-    function setBatchExpiryDates(uint256[] memory ids, uint256[] memory dates) external {
-        _setBatchExpiryDates(ids, dates);
-    }
-
     function mintToEOA(
         address to,
         uint256 id,

--- a/contracts/mocks/ERC1238ExpirableMock.sol
+++ b/contracts/mocks/ERC1238ExpirableMock.sol
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.0;
+
+import "../ERC1238/ERC1238.sol";
+import "../ERC1238/extensions/ERC1238Expirable.sol";
+import "../utils/AddressMinimal.sol";
+
+contract ERC1238ExpirableMock is ERC1238, ERC1238Expirable {
+    using Address for address;
+
+    constructor(string memory uri) ERC1238(uri) {}
+
+    function setExpiryDate(uint256 id, uint256 date) external {
+        _setExpiryDate(id, date);
+    }
+
+    function mintToEOA(
+        address to,
+        uint256 id,
+        uint256 amount,
+        uint8 v,
+        bytes32 r,
+        bytes32 s,
+        uint256 expiryDate,
+        bytes memory data
+    ) external {
+        _mintToEOA(to, id, amount, v, r, s, data);
+        _setExpiryDate(id, expiryDate);
+    }
+
+    function mintToContract(
+        address to,
+        uint256 id,
+        uint256 amount,
+        uint256 expiryDate,
+        bytes memory data
+    ) external {
+        _mintToContract(to, id, amount, data);
+        _setExpiryDate(id, expiryDate);
+    }
+
+    function mintBundle(
+        address[] memory to,
+        uint256[][] memory ids,
+        uint256[][] memory amounts,
+        uint256[][] memory expiryDates,
+        bytes[] memory data
+    ) external {
+        for (uint256 i = 0; i < to.length; i++) {
+            _setBatchExpiryDates(ids[i], expiryDates[i]);
+
+            if (to[i].isContract()) {
+                _mintBatchToContract(to[i], ids[i], amounts[i], data[i]);
+            } else {
+                (bytes32 r, bytes32 s, uint8 v) = splitSignature(data[i]);
+                _mintBatchToEOA(to[i], ids[i], amounts[i], v, r, s, data[i]);
+            }
+        }
+    }
+}

--- a/test/ERC1238/extensions/ERC1238Expirable.ts
+++ b/test/ERC1238/extensions/ERC1238Expirable.ts
@@ -18,13 +18,10 @@ describe("ERC1238Expirable", function () {
   let erc1238ExpirableMock: ERC1238ExpirableMock;
   let admin: SignerWithAddress;
   let contractRecipient: ERC1238ReceiverMock;
-  // let tokenBatchRecipient: SignerWithAddress;
 
   before(async function () {
     const signers: SignerWithAddress[] = await ethers.getSigners();
     admin = signers[0];
-    // tokenRecipient = signers[1];
-    // tokenBatchRecipient = signers[2];
   });
 
   beforeEach(async function () {
@@ -45,8 +42,6 @@ describe("ERC1238Expirable", function () {
 
     const tokenBatchIds = [toBN("2000"), toBN("2010"), toBN("2020")];
     const tokenBatchExpiryDates = [4110961215, 4110961216, 4110961217];
-    // const mintBatchAmounts = [toBN("5000"), toBN("10000"), toBN("42195")];
-    // const burnBatchAmounts = [toBN("5000"), toBN("9001"), toBN("195")];
 
     describe("_setExpiryDate", () => {
       it("should set the right expiry date", async () => {

--- a/test/ERC1238/extensions/ERC1238Expirable.ts
+++ b/test/ERC1238/extensions/ERC1238Expirable.ts
@@ -79,7 +79,7 @@ describe("ERC1238Expirable", function () {
     });
 
     describe("isExpired", () => {
-      it("should revert if the no expiry date was set", async () => {
+      it("should revert if no expiry date was set", async () => {
         await expect(erc1238ExpirableMock.isExpired(0)).to.be.revertedWith("ERC1238Expirable: No expiry date set");
       });
 
@@ -106,7 +106,7 @@ describe("ERC1238Expirable", function () {
     });
 
     describe("expiryDate", () => {
-      it("should revert if the no expiry date was set", async () => {
+      it("should revert if no expiry date was set", async () => {
         await expect(erc1238ExpirableMock.expiryDate(0)).to.be.revertedWith("ERC1238Expirable: No expiry date set");
       });
     });

--- a/test/ERC1238/extensions/ERC1238Expirable.ts
+++ b/test/ERC1238/extensions/ERC1238Expirable.ts
@@ -55,6 +55,14 @@ describe("ERC1238Expirable", function () {
           "ERC1238Expirable: Expiry date cannot be in the past",
         );
       });
+
+      it("should revert when trying to set an expiry date which is earlier than the currently set date", async () => {
+        await erc1238ExpirableMock.setExpiryDate(tokenId, tokenExpiryDate);
+
+        await expect(erc1238ExpirableMock.setExpiryDate(tokenId, tokenExpiryDate - 100)).to.be.revertedWith(
+          "ERC1238Expirable: Expiry date can only be extended",
+        );
+      });
     });
 
     describe("setBatchExpiryDates", () => {
@@ -70,6 +78,16 @@ describe("ERC1238Expirable", function () {
         await expect(
           erc1238ExpirableMock.setBatchExpiryDates(tokenBatchIds, tokenBatchExpiryDates.slice(1)),
         ).to.be.revertedWith("ERC1238Expirable: Ids and token URIs length mismatch");
+      });
+
+      it("should revert if a date shortens the expiry", async () => {
+        await erc1238ExpirableMock.setBatchExpiryDates(tokenBatchIds, tokenBatchExpiryDates);
+
+        const newDates = [tokenBatchExpiryDates[0] - 1, ...tokenBatchExpiryDates.slice(1)];
+
+        await expect(erc1238ExpirableMock.setBatchExpiryDates(tokenBatchIds, newDates)).to.be.revertedWith(
+          "ERC1238Expirable: Expiry date can only be extended",
+        );
       });
     });
 

--- a/test/ERC1238/extensions/ERC1238Expirable.ts
+++ b/test/ERC1238/extensions/ERC1238Expirable.ts
@@ -64,7 +64,7 @@ describe("ERC1238Expirable", function () {
     });
 
     describe("isExpired", () => {
-      it("should return for a token that is not expired", async () => {
+      it("should return false for a token that is not expired", async () => {
         await erc1238ExpirableMock.setExpiryDate(tokenId, tokenExpiryDate);
 
         expect(await erc1238ExpirableMock.isExpired(tokenId)).to.be.false;

--- a/test/ERC1238/extensions/ERC1238Expirable.ts
+++ b/test/ERC1238/extensions/ERC1238Expirable.ts
@@ -1,0 +1,87 @@
+import type { SignerWithAddress } from "@nomiclabs/hardhat-ethers/dist/src/signer-with-address";
+import { expect } from "chai";
+import { artifacts, ethers, waffle } from "hardhat";
+import type { Artifact } from "hardhat/types";
+import type { ERC1238ExpirableMock } from "../../../src/types/ERC1238ExpirableMock";
+import { toBN } from "../../utils/test-utils";
+
+const BASE_URI = "https://token-cdn-domain/{id}.json";
+const timestampInThePast = 955288375;
+
+const increaseEVMTime = async (time: number) => {
+  await ethers.provider.send("evm_increaseTime", [time]);
+  await ethers.provider.send("evm_mine", []);
+};
+
+describe("ERC1238Expirable", function () {
+  let erc1238ExpirableMock: ERC1238ExpirableMock;
+  let admin: SignerWithAddress;
+  // let tokenRecipient: SignerWithAddress;
+  // let tokenBatchRecipient: SignerWithAddress;
+
+  before(async function () {
+    const signers: SignerWithAddress[] = await ethers.getSigners();
+    admin = signers[0];
+    // tokenRecipient = signers[1];
+    // tokenBatchRecipient = signers[2];
+  });
+
+  beforeEach(async function () {
+    const ERC1238ExpirableMockArtifact: Artifact = await artifacts.readArtifact("ERC1238ExpirableMock");
+    erc1238ExpirableMock = <ERC1238ExpirableMock>(
+      await waffle.deployContract(admin, ERC1238ExpirableMockArtifact, [BASE_URI])
+    );
+  });
+
+  describe("internal functions", () => {
+    const data = "0x12345678";
+    const tokenId = toBN("11223344");
+    const tokenExpiryDate = 4110961214;
+    const mintAmount = toBN("58319");
+    const burnAmount = toBN("987");
+
+    const tokenBatchIds = [toBN("2000"), toBN("2010"), toBN("2020")];
+    const tokenBatchURIs = [
+      "https://ipfs.io/ipfs/Qme7ss3ARVgxv6rXqVPiikMJ8u2NLgmgszg13pYrDKEoiu",
+      "https://ipfs.io/ipfs/Qme7ss3ARVgxv6rXqVPiikMJ8u2NLgmgszg13pYrDKEoiv",
+      "https://ipfs.io/ipfs/Qme7ss3ARVgxv6rXqVPiikMJ8u2NLgmgszg13pYrDKEoiw",
+    ];
+    const mintBatchAmounts = [toBN("5000"), toBN("10000"), toBN("42195")];
+    const burnBatchAmounts = [toBN("5000"), toBN("9001"), toBN("195")];
+
+    describe("_setExpiryDate", () => {
+      it("should set the right expiry date", async () => {
+        await erc1238ExpirableMock.setExpiryDate(tokenId, tokenExpiryDate);
+
+        expect(await erc1238ExpirableMock.expiryDate(tokenId)).to.eq(tokenExpiryDate);
+      });
+
+      it("should revert when trying to set an expiry date in the past", async () => {
+        await expect(erc1238ExpirableMock.setExpiryDate(tokenId, timestampInThePast)).to.be.revertedWith(
+          "ERC1238Expirable: Expiry date cannot be in the past",
+        );
+      });
+    });
+
+    describe("isExpired", () => {
+      it("should return for a token that is not expired", async () => {
+        await erc1238ExpirableMock.setExpiryDate(tokenId, tokenExpiryDate);
+
+        expect(await erc1238ExpirableMock.isExpired(tokenId)).to.be.false;
+      });
+
+      it("should return true for an expired token", async () => {
+        const blockNumBefore = await ethers.provider.getBlockNumber();
+        const blockBefore = await ethers.provider.getBlock(blockNumBefore);
+        const blockTimestamp = blockBefore.timestamp;
+        const expiry = blockTimestamp + 100;
+
+        await erc1238ExpirableMock.setExpiryDate(tokenId, expiry);
+
+        await increaseEVMTime(200);
+
+        expect(await erc1238ExpirableMock.isExpired(tokenId)).to.be.true;
+      });
+    });
+  });
+});

--- a/test/ERC1238/extensions/ERC1238Expirable.ts
+++ b/test/ERC1238/extensions/ERC1238Expirable.ts
@@ -34,7 +34,7 @@ describe("ERC1238Expirable", function () {
     contractRecipient = <ERC1238ReceiverMock>await waffle.deployContract(admin, ERC1238ReceiverMockArtifact);
   });
 
-  describe("internal functions", () => {
+  describe("Expirable extension", () => {
     const data = "0x12345678";
     const tokenId = toBN("11223344");
     const tokenExpiryDate = 4110961214;
@@ -43,7 +43,7 @@ describe("ERC1238Expirable", function () {
     const tokenBatchIds = [toBN("2000"), toBN("2010"), toBN("2020")];
     const tokenBatchExpiryDates = [4110961215, 4110961216, 4110961217];
 
-    describe("_setExpiryDate", () => {
+    describe("setExpiryDate", () => {
       it("should set the right expiry date", async () => {
         await erc1238ExpirableMock.setExpiryDate(tokenId, tokenExpiryDate);
 
@@ -57,7 +57,7 @@ describe("ERC1238Expirable", function () {
       });
     });
 
-    describe("_setBatchExpiryDates", () => {
+    describe("setBatchExpiryDates", () => {
       it("should set the right expiry dates", async () => {
         await erc1238ExpirableMock.setBatchExpiryDates(tokenBatchIds, tokenBatchExpiryDates);
 
@@ -103,6 +103,12 @@ describe("ERC1238Expirable", function () {
     describe("expiryDate", () => {
       it("should revert if no expiry date was set", async () => {
         await expect(erc1238ExpirableMock.expiryDate(0)).to.be.revertedWith("ERC1238Expirable: No expiry date set");
+      });
+
+      it("should return the right expiry date", async () => {
+        await erc1238ExpirableMock.setExpiryDate(tokenId, tokenExpiryDate);
+
+        expect(await erc1238ExpirableMock.expiryDate(tokenId)).to.eq(tokenExpiryDate);
       });
     });
 

--- a/test/ERC1238/extensions/ERC1238Expirable.ts
+++ b/test/ERC1238/extensions/ERC1238Expirable.ts
@@ -74,10 +74,12 @@ describe("ERC1238Expirable", function () {
         const blockNumBefore = await ethers.provider.getBlockNumber();
         const blockBefore = await ethers.provider.getBlock(blockNumBefore);
         const blockTimestamp = blockBefore.timestamp;
+        // Setting the expiry 100 secs from now
         const expiry = blockTimestamp + 100;
 
         await erc1238ExpirableMock.setExpiryDate(tokenId, expiry);
 
+        // Increasing time by 200 seconds, so the token should be expired
         await increaseEVMTime(200);
 
         expect(await erc1238ExpirableMock.isExpired(tokenId)).to.be.true;


### PR DESCRIPTION
Optional extension which adds expiration to tokens using a simple mapping from token id to expiry date.
Relying parties can then check if a token is expired or not by calling `isExpired(id)`.