### PR TITLE
Add expiry and fix signature handling

### DIFF
--- a/contracts/ERC1238/ERC1238.sol
+++ b/contracts/ERC1238/ERC1238.sol
@@ -69,10 +69,10 @@ contract ERC1238 is ERC165, IERC1238, ERC1238Approval {
         override
         returns (uint256[] memory)
     {
-        uint256[] memory batchBalances = new uint256[](ids.length);
+        uint256 idsLength = ids.length;
+        uint256[] memory batchBalances = new uint256[](idsLength);
 
-        uint256 length = ids.length;
-        for (uint256 i = 0; i < length; ++i) {
+        for (uint256 i = 0; i < idsLength; ++i) {
             batchBalances[i] = balanceOf(account, ids[i]);
         }
 
@@ -90,10 +90,10 @@ contract ERC1238 is ERC165, IERC1238, ERC1238Approval {
         override
         returns (uint256[][] memory)
     {
-        uint256[][] memory bundleBalances = new uint256[][](accounts.length);
+        uint256 accountsLength = accounts.length;
+        uint256[][] memory bundleBalances = new uint256[][](accountsLength);
 
-        uint256 length = accounts.length;
-        for (uint256 i = 0; i < length; ++i) {
+        for (uint256 i = 0; i < accountsLength; ++i) {
             bundleBalances[i] = balanceOfBatch(accounts[i], ids[i]);
         }
 
@@ -246,7 +246,8 @@ contract ERC1238 is ERC165, IERC1238, ERC1238Approval {
         MintApprovalSignature[] calldata mintApprovalSignatures,
         bytes[] calldata data
     ) internal virtual {
-        for (uint256 i = 0; i < to.length; i++) {
+        uint256 toLength = to.length;
+        for (uint256 i = 0; i < toLength; i++) {
             if (to[i].isContract()) {
                 _mintBatchToContract(to[i], ids[i], amounts[i], data[i]);
             } else {
@@ -307,11 +308,12 @@ contract ERC1238 is ERC165, IERC1238, ERC1238Approval {
         uint256[] memory amounts,
         bytes memory data
     ) private {
-        require(ids.length == amounts.length, "ERC1238: ids and amounts length mismatch");
+        uint256 idsLength = ids.length;
+        require(idsLength == amounts.length, "ERC1238: ids and amounts length mismatch");
 
         address minter = msg.sender;
 
-        for (uint256 i = 0; i < ids.length; i++) {
+        for (uint256 i = 0; i < idsLength; i++) {
             _beforeMint(minter, to, ids[i], amounts[i], data);
 
             _balances[ids[i]][to] += amounts[i];
@@ -365,11 +367,13 @@ contract ERC1238 is ERC165, IERC1238, ERC1238Approval {
         uint256[] memory amounts
     ) internal virtual {
         require(from != address(0), "ERC1238: burn from the zero address");
-        require(ids.length == amounts.length, "ERC1238: ids and amounts length mismatch");
+
+        uint256 idsLength = ids.length;
+        require(idsLength == amounts.length, "ERC1238: ids and amounts length mismatch");
 
         address burner = msg.sender;
 
-        for (uint256 i = 0; i < ids.length; i++) {
+        for (uint256 i = 0; i < idsLength; i++) {
             uint256 id = ids[i];
             uint256 amount = amounts[i];
 

--- a/contracts/ERC1238/ERC1238.sol
+++ b/contracts/ERC1238/ERC1238.sol
@@ -167,7 +167,7 @@ contract ERC1238 is ERC165, IERC1238, ERC1238Approval {
         uint256 approvalExpiry,
         bytes memory data
     ) internal virtual {
-        require(approvalExpiry >= block.timestamp, "ERC1238: invalid approval expiry time");
+        require(approvalExpiry >= block.timestamp, "ERC1238: provided approval expiry time cannot be in the past");
 
         bytes32 messageHash = _getMintApprovalMessageHash(to, id, amount, approvalExpiry);
         _verifyMintingApproval(to, messageHash, v, r, s);
@@ -220,7 +220,7 @@ contract ERC1238 is ERC165, IERC1238, ERC1238Approval {
         uint256 approvalExpiry,
         bytes memory data
     ) internal virtual {
-        require(approvalExpiry >= block.timestamp, "ERC1238: invalid approval expiry time");
+        require(approvalExpiry >= block.timestamp, "ERC1238: provided approval expiry time cannot be in the past");
 
         bytes32 messageHash = _getMintBatchApprovalMessageHash(to, ids, amounts, approvalExpiry);
         _verifyMintingApproval(to, messageHash, v, r, s);

--- a/contracts/ERC1238/ERC1238Approval.sol
+++ b/contracts/ERC1238/ERC1238Approval.sol
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
+import "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
+
 struct EIP712Domain {
     string name;
     string version;
@@ -157,9 +159,9 @@ contract ERC1238Approval {
         // Prevent signatures from being replayed
         require(!hasApprovalHashBeenUsed[mintApprovalHash], "ERC1238: Approval hash already used");
 
-        bytes32 digest = keccak256(abi.encodePacked("\x19\x01", DOMAIN_SEPARATOR, mintApprovalHash));
+        bytes32 digest = ECDSA.toTypedDataHash(DOMAIN_SEPARATOR, mintApprovalHash);
 
-        require(ecrecover(digest, v, r, s) == recipient, "ERC1238: Approval verification failed");
+        require(ECDSA.recover(digest, v, r, s) == recipient, "ERC1238: Approval verification failed");
 
         hasApprovalHashBeenUsed[mintApprovalHash] = true;
     }

--- a/contracts/ERC1238/ERC1238Approval.sol
+++ b/contracts/ERC1238/ERC1238Approval.sol
@@ -14,6 +14,7 @@ struct MintBatchApproval {
     address recipient;
     uint256[] ids;
     uint256[] amounts;
+    uint256 approvalExpiry;
 }
 
 // Typed data of a Mint transaction
@@ -22,6 +23,14 @@ struct MintApproval {
     address recipient;
     uint256 id;
     uint256 amount;
+    uint256 approvalExpiry;
+}
+
+struct MintApprovalSignature {
+    uint8 v;
+    bytes32 r;
+    bytes32 s;
+    uint256 approvalExpiry;
 }
 
 /**
@@ -41,13 +50,15 @@ contract ERC1238Approval {
         keccak256("EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)");
 
     bytes32 private constant MINT_APPROVAL_TYPEHASH =
-        keccak256("MintApproval(address recipient,uint256 id,uint256 amount)");
+        keccak256("MintApproval(address recipient,uint256 id,uint256 amount,uint256 approvalExpiry)");
 
     bytes32 private constant MINT_BATCH_APPROVAL_TYPEHASH =
-        keccak256("MintBatchApproval(address recipient,uint256[] ids,uint256[] amounts)");
+        keccak256("MintBatchApproval(address recipient,uint256[] ids,uint256[] amounts,uint256 approvalExpiry)");
 
     // Domain Separator, as defined by EIP-712 (`hashstruct(eip712Domain)`)
     bytes32 public DOMAIN_SEPARATOR;
+
+    mapping(bytes32 => bool) private hasApprovalHashBeenUsed;
 
     constructor() {
         // The EIP712Domain shares the same name for all ERC128Approval contracts
@@ -79,11 +90,25 @@ contract ERC1238Approval {
     function _getMintApprovalMessageHash(
         address recipient,
         uint256 id,
-        uint256 amount
+        uint256 amount,
+        uint256 approvalExpiry
     ) internal pure returns (bytes32) {
-        MintApproval memory mintApproval = MintApproval({ recipient: recipient, id: id, amount: amount });
+        MintApproval memory mintApproval = MintApproval({
+            recipient: recipient,
+            id: id,
+            amount: amount,
+            approvalExpiry: approvalExpiry
+        });
         return
-            keccak256(abi.encode(MINT_APPROVAL_TYPEHASH, mintApproval.recipient, mintApproval.id, mintApproval.amount));
+            keccak256(
+                abi.encode(
+                    MINT_APPROVAL_TYPEHASH,
+                    mintApproval.recipient,
+                    mintApproval.id,
+                    mintApproval.amount,
+                    mintApproval.approvalExpiry
+                )
+            );
     }
 
     /**
@@ -95,12 +120,14 @@ contract ERC1238Approval {
     function _getMintBatchApprovalMessageHash(
         address recipient,
         uint256[] memory ids,
-        uint256[] memory amounts
+        uint256[] memory amounts,
+        uint256 approvalExpiry
     ) internal pure returns (bytes32) {
         MintBatchApproval memory mintBatchApproval = MintBatchApproval({
             recipient: recipient,
             ids: ids,
-            amounts: amounts
+            amounts: amounts,
+            approvalExpiry: approvalExpiry
         });
 
         return
@@ -109,7 +136,8 @@ contract ERC1238Approval {
                     MINT_BATCH_APPROVAL_TYPEHASH,
                     mintBatchApproval.recipient,
                     keccak256(abi.encodePacked(mintBatchApproval.ids)),
-                    keccak256(abi.encodePacked(mintBatchApproval.amounts))
+                    keccak256(abi.encodePacked(mintBatchApproval.amounts)),
+                    mintBatchApproval.approvalExpiry
                 )
             );
     }
@@ -125,9 +153,14 @@ contract ERC1238Approval {
         uint8 v,
         bytes32 r,
         bytes32 s
-    ) internal view {
+    ) internal {
+        // Prevent signatures from being replayed
+        require(!hasApprovalHashBeenUsed[mintApprovalHash], "ERC1238: Approval hash already used");
+
         bytes32 digest = keccak256(abi.encodePacked("\x19\x01", DOMAIN_SEPARATOR, mintApprovalHash));
 
         require(ecrecover(digest, v, r, s) == recipient, "ERC1238: Approval verification failed");
+
+        hasApprovalHashBeenUsed[mintApprovalHash] = true;
     }
 }

--- a/contracts/ERC1238/extensions/ERC1238URIStorage.sol
+++ b/contracts/ERC1238/extensions/ERC1238URIStorage.sol
@@ -54,9 +54,10 @@ abstract contract ERC1238URIStorage is ERC165, IERC1238URIStorage, ERC1238 {
      *
      */
     function _setBatchTokenURI(uint256[] memory ids, string[] memory tokenURIs) internal {
-        require(ids.length == tokenURIs.length, "ERC1238Storage: ids and token URIs length mismatch");
+        uint256 idsLength = ids.length;
+        require(idsLength == tokenURIs.length, "ERC1238Storage: ids and token URIs length mismatch");
 
-        for (uint256 i = 0; i < ids.length; i++) {
+        for (uint256 i = 0; i < idsLength; i++) {
             _setTokenURI(ids[i], tokenURIs[i]);
         }
     }

--- a/contracts/examples/Badge.sol
+++ b/contracts/examples/Badge.sol
@@ -32,7 +32,7 @@ contract Badge is ERC1238, ERC1238URIStorage {
         owner = newOwner;
     }
 
-    function setBaseURI(string memory newBaseURI) external onlyOwner {
+    function setBaseURI(string calldata newBaseURI) external onlyOwner {
         _setBaseURI(newBaseURI);
     }
 
@@ -43,10 +43,11 @@ contract Badge is ERC1238, ERC1238URIStorage {
         uint8 v,
         bytes32 r,
         bytes32 s,
-        string memory uri,
-        bytes memory data
+        uint256 approvalExpiry,
+        string calldata uri,
+        bytes calldata data
     ) external onlyOwner {
-        _mintToEOA(to, id, amount, v, r, s, data);
+        _mintToEOA(to, id, amount, v, r, s, approvalExpiry, data);
         _setTokenURI(id, uri);
     }
 
@@ -54,19 +55,20 @@ contract Badge is ERC1238, ERC1238URIStorage {
         address to,
         uint256 id,
         uint256 amount,
-        string memory uri,
-        bytes memory data
+        string calldata uri,
+        bytes calldata data
     ) external onlyOwner {
         _mintToContract(to, id, amount, data);
         _setTokenURI(id, uri);
     }
 
     function mintBundle(
-        address[] memory to,
-        uint256[][] memory ids,
-        uint256[][] memory amounts,
-        string[][] memory uris,
-        bytes[] memory data
+        address[] calldata to,
+        uint256[][] calldata ids,
+        uint256[][] calldata amounts,
+        string[][] calldata uris,
+        MintApprovalSignature[] calldata mintApprovalSignatures,
+        bytes[] calldata data
     ) external onlyOwner {
         for (uint256 i = 0; i < to.length; i++) {
             _setBatchTokenURI(ids[i], uris[i]);
@@ -74,8 +76,18 @@ contract Badge is ERC1238, ERC1238URIStorage {
             if (to[i].isContract()) {
                 _mintBatchToContract(to[i], ids[i], amounts[i], data[i]);
             } else {
-                (bytes32 r, bytes32 s, uint8 v) = splitSignature(data[i]);
-                _mintBatchToEOA(to[i], ids[i], amounts[i], v, r, s, data[i]);
+                MintApprovalSignature calldata signature = mintApprovalSignatures[i];
+
+                _mintBatchToEOA(
+                    to[i],
+                    ids[i],
+                    amounts[i],
+                    signature.v,
+                    signature.r,
+                    signature.s,
+                    signature.approvalExpiry,
+                    data[i]
+                );
             }
         }
     }
@@ -95,8 +107,8 @@ contract Badge is ERC1238, ERC1238URIStorage {
 
     function burnBatch(
         address from,
-        uint256[] memory ids,
-        uint256[] memory amounts,
+        uint256[] calldata ids,
+        uint256[] calldata amounts,
         bool deleteURI
     ) external onlyOwner {
         if (deleteURI) {
@@ -135,8 +147,8 @@ contract Badge is ERC1238, ERC1238URIStorage {
      */
     function _burnBatchAndDeleteURIs(
         address from,
-        uint256[] memory ids,
-        uint256[] memory amounts
+        uint256[] calldata ids,
+        uint256[] calldata amounts
     ) internal virtual {
         require(from != address(0), "ERC1238: burn from the zero address");
         require(ids.length == amounts.length, "ERC1238: ids and amounts length mismatch");

--- a/contracts/examples/Badge.sol
+++ b/contracts/examples/Badge.sol
@@ -70,7 +70,8 @@ contract Badge is ERC1238, ERC1238URIStorage {
         MintApprovalSignature[] calldata mintApprovalSignatures,
         bytes[] calldata data
     ) external onlyOwner {
-        for (uint256 i = 0; i < to.length; i++) {
+        uint256 toLength = to.length;
+        for (uint256 i = 0; i < toLength; i++) {
             _setBatchTokenURI(ids[i], uris[i]);
 
             if (to[i].isContract()) {
@@ -151,11 +152,13 @@ contract Badge is ERC1238, ERC1238URIStorage {
         uint256[] calldata amounts
     ) internal virtual {
         require(from != address(0), "ERC1238: burn from the zero address");
-        require(ids.length == amounts.length, "ERC1238: ids and amounts length mismatch");
+
+        uint256 idsLength = ids.length;
+        require(idsLength == amounts.length, "ERC1238: ids and amounts length mismatch");
 
         address burner = msg.sender;
 
-        for (uint256 i = 0; i < ids.length; i++) {
+        for (uint256 i = 0; i < idsLength; i++) {
             uint256 id = ids[i];
             uint256 amount = amounts[i];
 

--- a/contracts/mocks/ERC1238Mock.sol
+++ b/contracts/mocks/ERC1238Mock.sol
@@ -26,9 +26,10 @@ contract ERC1238Mock is ERC1238 {
         uint8 v,
         bytes32 r,
         bytes32 s,
+        uint256 approvalExpiry,
         bytes memory data
     ) external {
-        _mintToEOA(to, id, amount, v, r, s, data);
+        _mintToEOA(to, id, amount, v, r, s, approvalExpiry, data);
     }
 
     function mintToContract(
@@ -47,9 +48,10 @@ contract ERC1238Mock is ERC1238 {
         uint8 v,
         bytes32 r,
         bytes32 s,
+        uint256 approvalExpiry,
         bytes memory data
     ) external {
-        _mintBatchToEOA(to, ids, amounts, v, r, s, data);
+        _mintBatchToEOA(to, ids, amounts, v, r, s, approvalExpiry, data);
     }
 
     function mintBatchToContract(

--- a/contracts/mocks/ERC1238URIStorageMock.sol
+++ b/contracts/mocks/ERC1238URIStorageMock.sol
@@ -63,7 +63,8 @@ contract ERC1238URIStorageMock is ERC1238, ERC1238URIStorage {
         MintApprovalSignature[] calldata mintApprovalSignatures,
         bytes[] calldata data
     ) external {
-        for (uint256 i = 0; i < to.length; i++) {
+        uint256 toLength = to.length;
+        for (uint256 i = 0; i < toLength; i++) {
             _setBatchTokenURI(ids[i], uris[i]);
 
             if (to[i].isContract()) {
@@ -101,11 +102,13 @@ contract ERC1238URIStorageMock is ERC1238, ERC1238URIStorage {
         uint256[] calldata amounts
     ) external {
         require(from != address(0), "ERC1238: burn from the zero address");
-        require(ids.length == amounts.length, "ERC1238: ids and amounts length mismatch");
+
+        uint256 idsLength = ids.length;
+        require(idsLength == amounts.length, "ERC1238: ids and amounts length mismatch");
 
         address burner = msg.sender;
 
-        for (uint256 i = 0; i < ids.length; i++) {
+        for (uint256 i = 0; i < idsLength; i++) {
             uint256 id = ids[i];
             uint256 amount = amounts[i];
 

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@ethersproject/providers": "^5.5.0",
     "@nomiclabs/hardhat-ethers": "^2.0.2",
     "@nomiclabs/hardhat-waffle": "^2.0.1",
+    "@openzeppelin/contracts": "^4.7.0",
     "@typechain/ethers-v5": "^8.0.5",
     "@typechain/hardhat": "^3.0.0",
     "@types/chai": "^4.2.22",

--- a/src/utils/ERC1238Approval.ts
+++ b/src/utils/ERC1238Approval.ts
@@ -14,6 +14,7 @@ const MintApprovaltypes = {
     { name: "recipient", type: "address" },
     { name: "id", type: "uint256" },
     { name: "amount", type: "uint256" },
+    { name: "approvalExpiry", type: "uint256" },
   ],
 };
 const MintBatchApprovalTypes = {
@@ -21,6 +22,7 @@ const MintBatchApprovalTypes = {
     { name: "recipient", type: "address" },
     { name: "ids", type: "uint256[]" },
     { name: "amounts", type: "uint256[]" },
+    { name: "approvalExpiry", type: "uint256" },
   ],
 };
 
@@ -29,12 +31,14 @@ type MintApprovalStruct = {
   recipient: string;
   id: BigNumberish;
   amount: BigNumberish;
+  approvalExpiry: BigNumberish;
 };
 
 type MintBatchApprovalStruct = {
   recipient: string;
   ids: BigNumberish[];
   amounts: BigNumberish[];
+  approvalExpiry: BigNumberish;
 };
 
 export const getMintApprovalSignature = async ({
@@ -43,12 +47,14 @@ export const getMintApprovalSignature = async ({
   chainId,
   id,
   amount,
+  approvalExpiry,
 }: {
   signer: SignerWithAddress;
   erc1238ContractAddress: string;
   chainId: number;
   id: BigNumberish;
   amount: BigNumberish;
+  approvalExpiry: BigNumberish;
 }): Promise<Signature & { fullSignature: string }> => {
   const domain = getDomain(chainId, erc1238ContractAddress);
 
@@ -56,6 +62,7 @@ export const getMintApprovalSignature = async ({
     recipient: signer.address,
     id,
     amount,
+    approvalExpiry,
   };
 
   let sig: string;
@@ -75,22 +82,25 @@ export const getMintBatchApprovalSignature = async ({
   chainId,
   ids,
   amounts,
+  approvalExpiry,
 }: {
   signer: SignerWithAddress;
   erc1238ContractAddress: string;
   chainId: number;
   ids: BigNumberish[];
   amounts: BigNumberish[];
-}): Promise<Signature & { fullSignature: string }> => {
+  approvalExpiry: BigNumberish;
+}): Promise<Signature & { approvalExpiry: BigNumberish; fullSignature: string }> => {
   const domain = getDomain(chainId, erc1238ContractAddress);
 
   const value: MintBatchApprovalStruct = {
     recipient: signer.address,
     ids,
     amounts,
+    approvalExpiry,
   };
 
   const sig = await signer._signTypedData(domain, MintBatchApprovalTypes, value);
 
-  return { fullSignature: sig, ...ethers.utils.splitSignature(sig) };
+  return { fullSignature: sig, approvalExpiry, ...ethers.utils.splitSignature(sig) };
 };

--- a/test/ERC1238/ERC1238.ts
+++ b/test/ERC1238/ERC1238.ts
@@ -177,7 +177,7 @@ describe("ERC1238", function () {
 
         await expect(
           erc1238Mock.connect(admin).mintToEOA(tokenRecipient.address, tokenId, mintAmount, v, r, s, expiredTime, data),
-        ).to.be.revertedWith("ERC1238: invalid approval expiry time");
+        ).to.be.revertedWith("ERC1238: provided approval expiry time cannot be in the past");
       });
 
       it("should revert with a signature already used before", async () => {
@@ -262,7 +262,7 @@ describe("ERC1238", function () {
           erc1238Mock
             .connect(admin)
             .mintBatchToEOA(tokenBatchRecipient.address, tokenBatchIds, mintBatchAmounts, v, r, s, expiredTime, data),
-        ).to.be.revertedWith("ERC1238: invalid approval expiry time");
+        ).to.be.revertedWith("ERC1238: provided approval expiry time cannot be in the past");
       });
 
       it("should revert with a signature already used before", async () => {

--- a/test/utils/test-utils.ts
+++ b/test/utils/test-utils.ts
@@ -4,6 +4,8 @@ import * as interfaces from "./interfaces";
 
 export const ZERO_ADDRESS = "0x0000000000000000000000000000000000000000";
 export const TOKEN_ID_ZERO = 0;
+export const invalidSignatureV = 26;
+export const invalidSignatureS = "0x7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF5D576E7357A4501DDFE92F46681B20A1";
 
 export const toBN = (units: string, decimalPlaces: number = 18) => ethers.utils.parseUnits(units, decimalPlaces);
 export const formatBN = (amount: BigNumberish, decimalPlaces: number = 18) =>

--- a/yarn.lock
+++ b/yarn.lock
@@ -1561,6 +1561,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@openzeppelin/contracts@npm:^4.7.0":
+  version: 4.7.0
+  resolution: "@openzeppelin/contracts@npm:4.7.0"
+  checksum: ac917e668505ffbd300fcb00fd2f39b5f1153f77f82d482988336a881134b806b2d820f4293962691ef4d6f9f8ee5ecc71da82c6eb6ad2f02810511e90fa0d96
+  languageName: node
+  linkType: hard
+
 "@resolver-engine/core@npm:^0.3.3":
   version: 0.3.3
   resolution: "@resolver-engine/core@npm:0.3.3"
@@ -2258,6 +2265,7 @@ __metadata:
     "@ethersproject/providers": ^5.5.0
     "@nomiclabs/hardhat-ethers": ^2.0.2
     "@nomiclabs/hardhat-waffle": ^2.0.1
+    "@openzeppelin/contracts": ^4.7.0
     "@typechain/ethers-v5": ^8.0.5
     "@typechain/hardhat": ^3.0.0
     "@types/chai": ^4.2.22


### PR DESCRIPTION
Reflect the last changes made in [ERC1238-extendable](https://github.com/violetprotocol/erc1238-extendable)
- Add an expiry time to the mint approval messages
- Mint approval signatures can only be used once now (prevents replays)
- Minor gas optimizations
- Fix malleable signatures

I will update the docs once this PR is merged.